### PR TITLE
Enable saving in PNG

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = function mergeImages(
     color = 0x00000000,
     align = 'start',
     offset = 0,
+    isPng = false,
     margin
   } = {}
 ) {
@@ -125,7 +126,7 @@ module.exports = function mergeImages(
       baseImage.composite(img, px + left, py + top);
     }
 
-    return baseImage.getBase64Async(Jimp.MIME_JPEG);
+    return baseImage.getBase64Async(isPng ? Jimp.MIME_PNG : Jimp.MIME_JPEG);
     // return baseImage;
   });
 };


### PR DESCRIPTION
Your merge-base64 is an excellent tool. Enabling it to save in PNG can preserve 100% quality of the image and, more importantly, IG stories only allow PNG.

Hopefully you can publish it to npm if the pull request is accepted.